### PR TITLE
chore(plugin): built with kafka 2.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.okro.kafka</groupId>
     <artifactId>kafka-spiffe-principal</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <build>
         <plugins>
             <plugin>
@@ -23,8 +23,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
-            <version>1.1.1</version>
+            <artifactId>kafka_2.13</artifactId>
+            <version>2.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/src/test/java/io.okro.kafka/SpiffePrincipalBuilderTest.java
+++ b/src/test/java/io.okro.kafka/SpiffePrincipalBuilderTest.java
@@ -2,6 +2,7 @@ package io.okro.kafka;
 
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.auth.SslAuthenticationContext;
 import org.junit.Test;
 
@@ -31,7 +32,7 @@ public class SpiffePrincipalBuilderTest {
         // mock ssl session
         SSLSession session = mock(SSLSession.class);
         when(session.getPeerCertificates()).thenReturn(new Certificate[]{cert});
-        return new SslAuthenticationContext(session, InetAddress.getLocalHost());
+        return new SslAuthenticationContext(session, InetAddress.getLocalHost(), SecurityProtocol.SSL.name());
     }
 
     /**
@@ -79,7 +80,7 @@ public class SpiffePrincipalBuilderTest {
      */
     @Test
     public void TestNoSSLContext() throws java.net.UnknownHostException {
-        PlaintextAuthenticationContext context = new PlaintextAuthenticationContext(InetAddress.getLocalHost());
+        PlaintextAuthenticationContext context = new PlaintextAuthenticationContext(InetAddress.getLocalHost(), SecurityProtocol.SSL.name());
         KafkaPrincipal principal = new SpiffePrincipalBuilder().build(context);
 
         assertEquals(KafkaPrincipal.ANONYMOUS, principal);


### PR DESCRIPTION
- Built with Kafka 2.4.1
- Tests: add listener to ssl authentication context