### PR TITLE
Add compatibility with Kafka 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.okro.kafka</groupId>
     <artifactId>kafka-spiffe-principal</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0</version>
     <build>
         <plugins>
             <plugin>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>
-            <version>2.4.1</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/io.okro.kafka/SpiffePrincipalBuilderTest.java
+++ b/src/test/java/io.okro.kafka/SpiffePrincipalBuilderTest.java
@@ -85,4 +85,40 @@ public class SpiffePrincipalBuilderTest {
 
         assertEquals(KafkaPrincipal.ANONYMOUS, principal);
     }
+
+    @Test
+    public void TestSerdeWithAnonymous() throws UnknownHostException {
+        PlaintextAuthenticationContext context = new PlaintextAuthenticationContext(InetAddress.getLocalHost(), SecurityProtocol.SSL.name());
+        KafkaPrincipal principal = new SpiffePrincipalBuilder().build(context);
+
+        SpiffePrincipalBuilder spiffePrincipalBuilder = new SpiffePrincipalBuilder();
+        byte[] bytes = spiffePrincipalBuilder.serialize(principal);
+        KafkaPrincipal recoveredPrincipal = spiffePrincipalBuilder.deserialize(bytes);
+
+        assertEquals(principal, recoveredPrincipal);
+    }
+
+    @Test
+    public void TestSerdeWithSpiffe() throws CertificateException, UnknownHostException, SSLPeerUnverifiedException {
+        SslAuthenticationContext context = mockedSslContext("spiffe-cert.pem");
+        KafkaPrincipal principal = new SpiffePrincipalBuilder().build(context);
+
+        SpiffePrincipalBuilder spiffePrincipalBuilder = new SpiffePrincipalBuilder();
+        byte[] bytes = spiffePrincipalBuilder.serialize(principal);
+        KafkaPrincipal recoveredPrincipal = spiffePrincipalBuilder.deserialize(bytes);
+
+        assertEquals(principal, recoveredPrincipal);
+    }
+
+    @Test
+    public void TestSerdeWithUser() throws CertificateException, UnknownHostException, SSLPeerUnverifiedException {
+        SslAuthenticationContext context = mockedSslContext("subject-only-cert.pem");
+        KafkaPrincipal principal = new SpiffePrincipalBuilder().build(context);
+
+        SpiffePrincipalBuilder spiffePrincipalBuilder = new SpiffePrincipalBuilder();
+        byte[] bytes = spiffePrincipalBuilder.serialize(principal);
+        KafkaPrincipal recoveredPrincipal = spiffePrincipalBuilder.deserialize(bytes);
+
+        assertEquals(principal, recoveredPrincipal);
+    }
 }


### PR DESCRIPTION
There was a breaking change in Kafka 3.0 related to `principal.builder.class`:

> Custom principal builder implementations specified through principal.builder.class must now implement the KafkaPrincipalSerde interface to allow for forwarding between brokers. See KIP-590 for more details about the usage of KafkaPrincipalSerde.

This change implements the `KafkaPrincipalSerde` interface as above requirements.